### PR TITLE
upgrade tendermint version

### DIFF
--- a/cmd/qosd/main.go
+++ b/cmd/qosd/main.go
@@ -31,8 +31,7 @@ func main() {
 	// version cmd
 	rootCmd.AddCommand(version.VersionCmd)
 
-	server.AddCommands(ctx, cdc, rootCmd, app.QOSAppInit(),
-		server.ConstructAppCreator(newApp, "qos"))
+	server.AddCommands(ctx, cdc, rootCmd, app.QOSAppInit(), newApp)
 
 	rootCmd.AddCommand(qosdinit.ConfigRootCA(cdc))
 	rootCmd.AddCommand(qosdinit.AddGenesisAccount(cdc))

--- a/cmd/qosd/testnet/testnet.go
+++ b/cmd/qosd/testnet/testnet.go
@@ -99,7 +99,7 @@ Example:
 
 			// validators
 			for i := 0; i < nValidators; i++ {
-				nodeDirName := cmn.Fmt("%s%d", nodeDirPrefix, i)
+				nodeDirName := fmt.Sprintf("%s%d", nodeDirPrefix, i)
 				nodeDir := filepath.Join(outputDir, nodeDirName)
 				config.SetRoot(nodeDir)
 
@@ -133,7 +133,7 @@ Example:
 
 			// non-validators
 			for i := 0; i < nNonValidators; i++ {
-				nodeDir := filepath.Join(outputDir, cmn.Fmt("%s%d", nodeDirPrefix, i+nValidators))
+				nodeDir := filepath.Join(outputDir, fmt.Sprintf("%s%d", nodeDirPrefix, i+nValidators))
 				config.SetRoot(nodeDir)
 
 				err := os.MkdirAll(filepath.Join(nodeDir, "config"), nodeDirPerm)
@@ -176,7 +176,7 @@ Example:
 
 			// Write genesis file.
 			for i := 0; i < nValidators+nNonValidators; i++ {
-				nodeDir := filepath.Join(outputDir, cmn.Fmt("%s%d", nodeDirPrefix, i))
+				nodeDir := filepath.Join(outputDir, fmt.Sprintf("%s%d", nodeDirPrefix, i))
 				if err := genDoc.SaveAs(filepath.Join(nodeDir, config.BaseConfig.Genesis)); err != nil {
 					_ = os.RemoveAll(outputDir)
 					return err
@@ -243,7 +243,7 @@ func hostnameOrIP(i int) string {
 func populatePersistentPeersInConfigAndWriteIt(config *cfg.Config) error {
 	persistentPeers := make([]string, nValidators+nNonValidators)
 	for i := 0; i < nValidators+nNonValidators; i++ {
-		nodeDir := filepath.Join(outputDir, cmn.Fmt("%s%d", nodeDirPrefix, i))
+		nodeDir := filepath.Join(outputDir, fmt.Sprintf("%s%d", nodeDirPrefix, i))
 		config.SetRoot(nodeDir)
 		nodeKey, err := p2p.LoadNodeKey(config.NodeKeyFile())
 		if err != nil {
@@ -254,7 +254,7 @@ func populatePersistentPeersInConfigAndWriteIt(config *cfg.Config) error {
 	persistentPeersList := strings.Join(persistentPeers, ",")
 
 	for i := 0; i < nValidators+nNonValidators; i++ {
-		nodeDir := filepath.Join(outputDir, cmn.Fmt("%s%d", nodeDirPrefix, i))
+		nodeDir := filepath.Join(outputDir, fmt.Sprintf("%s%d", nodeDirPrefix, i))
 		config.SetRoot(nodeDir)
 		config.P2P.PersistentPeers = persistentPeersList
 		config.P2P.AddrBookStrict = false
@@ -288,7 +288,7 @@ func initFilesWithConfig(config *cfg.Config) error {
 	genFile := config.GenesisFile()
 	if !cmn.FileExists(genFile) {
 		genDoc := ttypes.GenesisDoc{
-			ChainID:         cmn.Fmt("test-chain-%v", cmn.RandStr(6)),
+			ChainID:         fmt.Sprintf("test-chain-%v", cmn.RandStr(6)),
 			GenesisTime:     time.Now(),
 			ConsensusParams: ttypes.DefaultConsensusParams(),
 		}

--- a/go.mod
+++ b/go.mod
@@ -4,14 +4,14 @@ module github.com/QOSGroup/qos
 
 require (
 	github.com/QOSGroup/kepler v0.5.0
-	github.com/QOSGroup/qbase v0.0.9
+	github.com/QOSGroup/qbase v0.0.10-0.20181227070220-b38732e92391
+	github.com/ebuchman/fail-test v0.0.0-20170303061230-95f809107225 // indirect
 	github.com/pkg/errors v0.8.0
 
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.0.0
 	github.com/stretchr/testify v1.2.2
-	github.com/tendermint/go-amino v0.12.0
-	github.com/tendermint/tendermint v0.23.1
-	github.com/tendermint/tmlibs v0.9.0 // indirect
+	github.com/tendermint/go-amino v0.14.1
+	github.com/tendermint/tendermint v0.27.3
 )

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ module github.com/QOSGroup/qos
 require (
 	github.com/QOSGroup/kepler v0.5.0
 	github.com/QOSGroup/qbase v0.0.10-0.20190103070009-bd308f2b6d6e
-	github.com/ebuchman/fail-test v0.0.0-20170303061230-95f809107225 // indirect
 	github.com/pkg/errors v0.8.0
 
 	github.com/spf13/cobra v0.0.3

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ module github.com/QOSGroup/qos
 
 require (
 	github.com/QOSGroup/kepler v0.5.0
-	github.com/QOSGroup/qbase v0.0.10-0.20181227070220-b38732e92391
+	github.com/QOSGroup/qbase v0.0.10-0.20190103070009-bd308f2b6d6e
 	github.com/ebuchman/fail-test v0.0.0-20170303061230-95f809107225 // indirect
 	github.com/pkg/errors v0.8.0
 

--- a/txs/approve/approve.go
+++ b/txs/approve/approve.go
@@ -4,14 +4,15 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
+
 	bacc "github.com/QOSGroup/qbase/account"
 	"github.com/QOSGroup/qbase/context"
 	"github.com/QOSGroup/qbase/txs"
 	btypes "github.com/QOSGroup/qbase/types"
 	"github.com/QOSGroup/qos/account"
 	"github.com/QOSGroup/qos/types"
-	"sort"
-	"strings"
 )
 
 // 授权 Common 结构
@@ -211,7 +212,7 @@ func (tx TxCreateApprove) ValidateData(ctx context.Context) error {
 
 func (tx TxCreateApprove) Exec(ctx context.Context) (result btypes.Result, crossTxQcps *txs.TxQcp) {
 	result = btypes.Result{
-		Code: btypes.ABCICodeOK,
+		Code: btypes.CodeOK,
 	}
 
 	accountMapper := ctx.Mapper(bacc.AccountMapperName).(*bacc.AccountMapper)
@@ -256,14 +257,14 @@ func (tx TxIncreaseApprove) ValidateData(ctx context.Context) error {
 
 func (tx TxIncreaseApprove) Exec(ctx context.Context) (result btypes.Result, crossTxQcps *txs.TxQcp) {
 	result = btypes.Result{
-		Code: btypes.ABCICodeOK,
+		Code: btypes.CodeOK,
 	}
 	mapper := ctx.Mapper(GetApproveMapperStoreKey()).(*ApproveMapper)
 
 	// 校验授权信息
 	approve, exisit := mapper.GetApprove(tx.From, tx.To)
 	if !exisit {
-		result.Code = btypes.ABCICodeType(btypes.CodeInternal)
+		result.Code = btypes.CodeOK
 		return
 	}
 
@@ -301,18 +302,18 @@ func (tx TxDecreaseApprove) ValidateData(ctx context.Context) error {
 
 func (tx TxDecreaseApprove) Exec(ctx context.Context) (result btypes.Result, crossTxQcps *txs.TxQcp) {
 	result = btypes.Result{
-		Code: btypes.ABCICodeOK,
+		Code: btypes.CodeOK,
 	}
 	mapper := ctx.Mapper(GetApproveMapperStoreKey()).(*ApproveMapper)
 
 	// 校验授权信息
 	approve, exisit := mapper.GetApprove(tx.From, tx.To)
 	if !exisit {
-		result.Code = btypes.ABCICodeType(btypes.CodeInternal)
+		result.Code = btypes.CodeInternal
 		return
 	}
 	if !approve.IsGTE(tx.QOS, tx.QSCs) {
-		result.Code = btypes.ABCICodeType(btypes.CodeInternal)
+		result.Code = btypes.CodeInternal
 		return
 	}
 
@@ -360,7 +361,7 @@ func (tx TxUseApprove) ValidateData(ctx context.Context) error {
 
 func (tx TxUseApprove) Exec(ctx context.Context) (result btypes.Result, crossTxQcps *txs.TxQcp) {
 	result = btypes.Result{
-		Code: btypes.ABCICodeOK,
+		Code: btypes.CodeOK,
 	}
 	accountMapper := ctx.Mapper(bacc.AccountMapperName).(*bacc.AccountMapper)
 	from := accountMapper.GetAccount(tx.From).(*account.QOSAccount)
@@ -371,17 +372,17 @@ func (tx TxUseApprove) Exec(ctx context.Context) (result btypes.Result, crossTxQ
 	// 校验授权信息
 	approve, exisit := approveMapper.GetApprove(tx.From, tx.To)
 	if !exisit {
-		result.Code = btypes.ABCICodeType(btypes.CodeInternal)
+		result.Code = btypes.CodeInternal
 		return
 	}
 	if !approve.IsGTE(tx.QOS, tx.QSCs) {
-		result.Code = btypes.ABCICodeType(btypes.CodeInternal)
+		result.Code = btypes.CodeInternal
 		return
 	}
 
 	// 校验授权用户状态
 	if tx.IsGT(from.QOS, from.QSCs) {
-		result.Code = btypes.ABCICodeType(btypes.CodeInternal)
+		result.Code = btypes.CodeInternal
 		return
 	}
 
@@ -434,20 +435,20 @@ func (tx TxCancelApprove) ValidateData(ctx context.Context) error {
 
 func (tx TxCancelApprove) Exec(ctx context.Context) (result btypes.Result, crossTxQcps *txs.TxQcp) {
 	result = btypes.Result{
-		Code: btypes.ABCICodeOK,
+		Code: btypes.CodeOK,
 	}
 
 	// 授权是否存在
 	mapper := ctx.Mapper(GetApproveMapperStoreKey()).(*ApproveMapper)
 	_, exists := mapper.GetApprove(tx.From, tx.To)
 	if !exists {
-		result.Code = btypes.ABCICodeType(btypes.CodeInternal)
+		result.Code = btypes.CodeInternal
 		return
 	}
 
 	err := mapper.DeleteApprove(tx.From, tx.To)
 	if err != nil {
-		result.Code = btypes.ABCICodeType(btypes.CodeInternal)
+		result.Code = btypes.CodeInternal
 		return
 	}
 

--- a/txs/approve/approve_test.go
+++ b/txs/approve/approve_test.go
@@ -251,7 +251,7 @@ func TestTxApproveCreate_Exec(t *testing.T) {
 	}
 	result, cross := tx.Exec(ctx)
 	require.Nil(t, cross)
-	require.Equal(t, result.Code, btypes.ABCICodeOK)
+	require.Equal(t, result.Code, btypes.CodeOK)
 
 	approveMapper := ctx.Mapper(GetApproveMapperStoreKey()).(*ApproveMapper)
 	approve, exists := approveMapper.GetApprove(tx.From, tx.To)
@@ -293,7 +293,7 @@ func TestTxApproveIncrease_Exec(t *testing.T) {
 
 	result, cross := increaseTx.Exec(ctx)
 	require.Nil(t, cross)
-	require.Equal(t, result.Code, btypes.ABCICodeOK)
+	require.Equal(t, result.Code, btypes.CodeOK)
 
 	approve, exists := approveMapper.GetApprove(createTx.From, createTx.To)
 	require.True(t, exists)
@@ -339,7 +339,7 @@ func TestTxApproveDecrease_Exec(t *testing.T) {
 
 	result, cross := decreaseTx.Exec(ctx)
 	require.Nil(t, cross)
-	require.Equal(t, result.Code, btypes.ABCICodeOK)
+	require.Equal(t, result.Code, btypes.CodeOK)
 
 	approve, exists := approveMapper.GetApprove(createTx.From, createTx.To)
 	require.True(t, exists)
@@ -402,7 +402,7 @@ func TestTxApproveUse_Exec(t *testing.T) {
 
 	result, cross := useTx.Exec(ctx)
 	require.Nil(t, cross)
-	require.NotEqual(t, result.Code, btypes.ABCICodeOK)
+	require.NotEqual(t, result.Code, btypes.CodeOK)
 
 	createTx.QOS = btypes.NewInt(1)
 	approveMapper := ctx.Mapper(GetApproveMapperStoreKey()).(*ApproveMapper)
@@ -411,7 +411,7 @@ func TestTxApproveUse_Exec(t *testing.T) {
 
 	result, cross = useTx.Exec(ctx)
 	require.Nil(t, cross)
-	require.NotEqual(t, result.Code, btypes.ABCICodeOK)
+	require.NotEqual(t, result.Code, btypes.CodeOK)
 
 	createTx.QOS = btypes.NewInt(100)
 	err = approveMapper.SaveApprove(createTx.Approve)
@@ -419,7 +419,7 @@ func TestTxApproveUse_Exec(t *testing.T) {
 
 	result, cross = useTx.Exec(ctx)
 	require.Nil(t, cross)
-	require.Equal(t, result.Code, btypes.ABCICodeOK)
+	require.Equal(t, result.Code, btypes.CodeOK)
 
 	approve, exists := approveMapper.GetApprove(useTx.From, useTx.To)
 	require.True(t, exists)
@@ -456,14 +456,14 @@ func TestTxApproveCancel_Exec(t *testing.T) {
 	}
 	result, cross := cancelTx.Exec(ctx)
 	require.Nil(t, cross)
-	require.NotEqual(t, result.Code, btypes.ABCICodeOK)
+	require.NotEqual(t, result.Code, btypes.CodeOK)
 
 	mapper := ctx.Mapper(GetApproveMapperStoreKey()).(*ApproveMapper)
 	err := mapper.SaveApprove(createTx.Approve)
 	require.Nil(t, err)
 
 	result, _ = cancelTx.Exec(ctx)
-	require.Equal(t, result.Code, btypes.ABCICodeOK)
+	require.Equal(t, result.Code, btypes.CodeOK)
 
 }
 

--- a/txs/qcp/qcp.go
+++ b/txs/qcp/qcp.go
@@ -63,7 +63,7 @@ func (tx TxInitQCP) ValidateData(ctx context.Context) error {
 
 func (tx TxInitQCP) Exec(ctx context.Context) (result btypes.Result, crossTxQcp *txs.TxQcp) {
 	result = btypes.Result{
-		Code: btypes.ABCICodeOK,
+		Code: btypes.CodeOK,
 	}
 
 	subj := tx.QCPCA.CSR.Subj.(cert.QCPSubject)

--- a/txs/qsc/qsc.go
+++ b/txs/qsc/qsc.go
@@ -78,7 +78,7 @@ func (tx TxCreateQSC) ValidateData(ctx context.Context) error {
 
 func (tx TxCreateQSC) Exec(ctx context.Context) (result btypes.Result, crossTxQcp *txs.TxQcp) {
 	result = btypes.Result{
-		Code: btypes.ABCICodeOK,
+		Code: btypes.CodeOK,
 	}
 
 	qscInfo := types.NewQSCInfoWithQSCCA(tx.QSCCA)
@@ -180,7 +180,7 @@ func (tx TxIssueQSC) ValidateData(ctx context.Context) error {
 
 func (tx TxIssueQSC) Exec(ctx context.Context) (result btypes.Result, crossTxQcp *txs.TxQcp) {
 	result = btypes.Result{
-		Code: btypes.ABCICodeOK,
+		Code: btypes.CodeOK,
 	}
 
 	accountMapper := ctx.Mapper(bacc.AccountMapperName).(*bacc.AccountMapper)

--- a/txs/staking/client/query.go
+++ b/txs/staking/client/query.go
@@ -133,7 +133,7 @@ func queryAllValidatorsCommand(cdc *go_amino.Codec) *cobra.Command {
 			var validators []validatorDisplayInfo
 
 			var vKVPair []store.KVPair
-			cdc.UnmarshalBinary(valueBz, &vKVPair)
+			cdc.UnmarshalBinaryLengthPrefixed(valueBz, &vKVPair)
 			for _, kv := range vKVPair {
 				var validator types.Validator
 				cdc.UnmarshalBinaryBare(kv.Value, &validator)
@@ -325,7 +325,7 @@ func queryValidatorVotesInWindow(ctx context.CLIContext, validatorAddr btypes.Ad
 	}
 
 	var vKVPair []store.KVPair
-	ctx.Codec.UnmarshalBinary(valueBz, &vKVPair)
+	ctx.Codec.UnmarshalBinaryLengthPrefixed(valueBz, &vKVPair)
 
 	for _, kv := range vKVPair {
 		k := kv.Key
@@ -383,7 +383,7 @@ func buildQueryOptions() client.ABCIQueryOptions {
 	trust := viper.GetBool(bctypes.FlagTrustNode)
 
 	return client.ABCIQueryOptions{
-		Height:  height,
-		Trusted: trust,
+		Height: height,
+		Prove:  trust,
 	}
 }

--- a/txs/staking/validator.go
+++ b/txs/staking/validator.go
@@ -91,7 +91,7 @@ func (tx *TxCreateValidator) Exec(ctx context.Context) (result btypes.Result, cr
 	validatorMapper := ctx.Mapper(ValidatorMapperName).(*ValidatorMapper)
 	validatorMapper.CreateValidator(validator)
 
-	return btypes.Result{Code: btypes.ABCICodeOK}, nil
+	return btypes.Result{Code: btypes.CodeOK}, nil
 }
 
 func (tx *TxCreateValidator) GetSigner() []btypes.Address {
@@ -150,11 +150,11 @@ func (tx *TxRevokeValidator) Exec(ctx context.Context) (result btypes.Result, cr
 	mapper := ctx.Mapper(ValidatorMapperName).(*ValidatorMapper)
 	validator, exists := mapper.GetValidatorByOwner(tx.Owner)
 	if !exists {
-		return btypes.Result{Code: btypes.ABCICodeType(btypes.CodeInternal)}, nil
+		return btypes.Result{Code: btypes.CodeInternal}, nil
 	}
 	mapper.MakeValidatorInactive(validator.ValidatorPubKey.Address().Bytes(), uint64(ctx.BlockHeight()), ctx.BlockHeader().Time.UTC(), types.Revoke)
 
-	return btypes.Result{Code: btypes.ABCICodeOK}, nil
+	return btypes.Result{Code: btypes.CodeOK}, nil
 }
 
 func (tx *TxRevokeValidator) GetSigner() []btypes.Address {
@@ -209,7 +209,7 @@ func (tx *TxActiveValidator) Exec(ctx context.Context) (result btypes.Result, cr
 	mapper := ctx.Mapper(ValidatorMapperName).(*ValidatorMapper)
 	validator, exists := mapper.GetValidatorByOwner(tx.Owner)
 	if !exists {
-		return btypes.Result{Code: btypes.ABCICodeType(btypes.CodeInternal)}, nil
+		return btypes.Result{Code: btypes.CodeInternal}, nil
 	}
 	mapper.MakeValidatorActive(validator.ValidatorPubKey.Address().Bytes())
 
@@ -217,7 +217,7 @@ func (tx *TxActiveValidator) Exec(ctx context.Context) (result btypes.Result, cr
 	voteInfo := types.NewValidatorVoteInfo(validator.BondHeight+1, 0, 0)
 	voteInfoMapper.ResetValidatorVoteInfo(validator.ValidatorPubKey.Address().Bytes(), voteInfo)
 
-	return btypes.Result{Code: btypes.ABCICodeOK}, nil
+	return btypes.Result{Code: btypes.CodeOK}, nil
 }
 
 func (tx *TxActiveValidator) GetSigner() []btypes.Address {

--- a/txs/transfer/transfer.go
+++ b/txs/transfer/transfer.go
@@ -126,7 +126,7 @@ func (tx TxTransfer) Exec(ctx context.Context) (result btypes.Result, crossTxQcp
 		accountMapper.SetAccount(acc)
 	}
 
-	return btypes.Result{Code: btypes.ABCICodeOK}, nil
+	return btypes.Result{Code: btypes.CodeOK}, nil
 }
 
 // 所有Senders

--- a/types/validator.go
+++ b/types/validator.go
@@ -40,10 +40,24 @@ type Validator struct {
 	BondHeight uint64 `json:"bondHeight"`
 }
 
+func (val Validator) GetValidatorAddress() btypes.Address {
+	return btypes.Address(val.ValidatorPubKey.Address())
+}
+
 func (val Validator) ToABCIValidator() (abciVal abci.Validator) {
-	abciVal.PubKey = tmtypes.TM2PB.PubKey(val.ValidatorPubKey)
+	// abciVal.PubKey = tmtypes.TM2PB.PubKey(val.ValidatorPubKey)
 	abciVal.Power = int64(val.BondTokens)
 	abciVal.Address = val.ValidatorPubKey.Address()
+	return
+}
+
+func (val Validator) ToABCIValidatorUpdate(isRemoved bool) (abciVal abci.ValidatorUpdate) {
+	abciVal.PubKey = tmtypes.TM2PB.PubKey(val.ValidatorPubKey)
+	if isRemoved {
+		abciVal.Power = int64(0)
+	} else {
+		abciVal.Power = int64(val.BondTokens)
+	}
 	return
 }
 

--- a/x/miner/abci.go
+++ b/x/miner/abci.go
@@ -49,7 +49,7 @@ func rewardVoteValidator(ctx context.Context, req abci.RequestBeginBlock, reward
 	validatorMapper := staking.GetValidatorMapper(ctx)
 
 	totalVotePower := int64(0)
-	for _, val := range req.LastCommitInfo.Validators {
+	for _, val := range req.LastCommitInfo.Votes {
 		if val.SignedLastBlock {
 			totalVotePower += val.Validator.Power
 		}
@@ -62,7 +62,7 @@ func rewardVoteValidator(ctx context.Context, req abci.RequestBeginBlock, reward
 
 	actualAppliedQOSAccount := btypes.NewInt(0)
 
-	for _, val := range req.LastCommitInfo.Validators {
+	for _, val := range req.LastCommitInfo.Votes {
 		if val.SignedLastBlock {
 			//reward
 			addr := btypes.Address(val.Validator.Address)


### PR DESCRIPTION
修改内容:
1.  tendermint移除common.Fmt 方法, 使用fmt.Sprintf
2.  qbase中返回码ABCICodeOK修改为CodeOK
3.  amino中UnmarshalBinary方法名变更为UnmarshalBinaryLengthPrefixed
4.  abci查询选项ABCIQueryOptions中Trusted名称变更为Prove
5.  endblock中返回validator变更信息,返回值由abci.Validators变更为abci.ValidatorUpdate