### PR TITLE
更新验证节点查询和修改

### DIFF
--- a/module/stake/client/query.go
+++ b/module/stake/client/query.go
@@ -33,7 +33,6 @@ const (
 )
 
 type validatorDisplayInfo struct {
-	Name            string               `json:"name"`
 	Owner           btypes.Address       `json:"owner"`
 	ValidatorAddr   string               `json:"validatorAddress"`
 	ValidatorPubKey crypto.PubKey        `json:"validatorPubkey"`

--- a/module/stake/client/validator.go
+++ b/module/stake/client/validator.go
@@ -97,7 +97,6 @@ func ModifyValidatorCmd(cdc *amino.Codec) *cobra.Command {
 	cmd.Flags().String(flagWebsite, "", "The validator's (optional) website")
 	cmd.Flags().String(flagDetails, "", "The validator's (optional) details")
 
-	cmd.MarkFlagRequired(flagMoniker)
 	cmd.MarkFlagRequired(flagOwner)
 
 	return cmd


### PR DESCRIPTION
- `modify-validator`中`moniker `非必填
- 查询验证节点时没有`name`字段